### PR TITLE
Priority channel context

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ channelsWithPriority := []channels.ChannelWithPriority[string]{
 // Two possible usage modes
 
 // 1. Create a priority channel and receive messages from it explicitly
-ch := priority_channels.NewByHighestAlwaysFirst(channelsWithPriority)
+ch := priority_channels.NewByHighestAlwaysFirst(ctx, channelsWithPriority)
 for {
-    message, channelName, ok := ch.Receive(ctx)
+    message, channelName, ok := ch.Receive()
     if !ok {
         break
     }
@@ -85,9 +85,9 @@ channelsWithFrequencyRatio := []channels.ChannelFreqRatio[string]{
 // Two possible usage modes
 
 // 1. Create a priority channel and receive messages from it explicitly
-ch := priority_channels.NewByFrequencyRatio(channelsWithFrequencyRatio)
+ch := priority_channels.NewByFrequencyRatio(ctx, channelsWithFrequencyRatio)
 for {
-    message, channelName, ok := ch.Receive(ctx)
+    message, channelName, ok := ch.Receive()
     if !ok {
         break
     }
@@ -112,11 +112,11 @@ freeUserLowPriorityC := make(chan string)
 
 priorityChannelsWithPriority := []priority_channel_groups.PriorityChannelWithPriority[string]{
     {
-        PriorityChannel: priority_channels.WrapAsPriorityChannel("Urgent Messages", urgentMessagesC),
+        PriorityChannel: priority_channels.WrapAsPriorityChannel(ctx, "Urgent Messages", urgentMessagesC),
         Priority:        100,
     },
     {
-        PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+        PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
             channels.NewChannelWithFreqRatio(
                 "Paying Customer - High Priority",
                 payingCustomerHighPriorityC,
@@ -129,7 +129,7 @@ priorityChannelsWithPriority := []priority_channel_groups.PriorityChannelWithPri
         Priority: 10,
     },
     {
-        PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+        PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
             channels.NewChannelWithFreqRatio(
                 "Free User - High Priority",
                 freeUserHighPriorityC,
@@ -148,7 +148,7 @@ priorityChannelsWithPriority := []priority_channel_groups.PriorityChannelWithPri
 // 1. Create a priority channel and receive messages from it explicitly
 ch := priority_channel_groups.CombineByHighestPriorityFirst(ctx, priorityChannelsWithPriority)
 for {
-    message, channelName, ok := ch.Receive(ctx)
+    message, channelName, ok := ch.Receive()
     if !ok {
         break
     }
@@ -176,11 +176,11 @@ freeUserLowPriorityC := make(chan string)
 
 priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
     {
-        PriorityChannel: priority_channels.WrapAsPriorityChannel("Urgent Messages", urgentMessagesC),
+        PriorityChannel: priority_channels.WrapAsPriorityChannel(ctx, "Urgent Messages", urgentMessagesC),
         FreqRatio:       100,
     },
     {
-        PriorityChannel: priority_channels.NewByHighestAlwaysFirst([]channels.ChannelWithPriority[string]{
+        PriorityChannel: priority_channels.NewByHighestAlwaysFirst(ctx, []channels.ChannelWithPriority[string]{
             channels.NewChannelWithPriority(
                 "Paying Customer - High Priority",
                 payingCustomerHighPriorityC,
@@ -193,7 +193,7 @@ priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFr
         FreqRatio: 10,
     },
     {
-        PriorityChannel: priority_channels.NewByHighestAlwaysFirst([]channels.ChannelWithPriority[string]{
+        PriorityChannel: priority_channels.NewByHighestAlwaysFirst(ctx, []channels.ChannelWithPriority[string]{
             channels.NewChannelWithPriority(
                 "Free User - High Priority",
                 freeUserHighPriorityC,
@@ -212,7 +212,7 @@ priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFr
 // 1. Create a priority channel and receive messages from it explicitly
 ch := priority_channel_groups.CombineByFrequencyRatio(ctx, priorityChannelsWithFreqRatio)
 for {
-    message, channelName, ok := ch.Receive(ctx)
+    message, channelName, ok := ch.Receive()
     if !ok {
         break
     }
@@ -244,7 +244,7 @@ nicheProductFreeUserLowPriorityC := make(chan string)
 
 flagshipProductChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
     {
-        PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+        PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
             channels.NewChannelWithFreqRatio(
                 "Flagship Product - Paying Customer - High Priority",
                 flagshipProductPayingCustomerHighPriorityC,
@@ -257,7 +257,7 @@ flagshipProductChannelsWithFreqRatio := []priority_channel_groups.PriorityChanne
         FreqRatio: 10,
     },
     {
-        PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+        PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
             channels.NewChannelWithFreqRatio(
                 "Flagship Product - Free User - High Priority",
                 flagshipProductFreeUserHighPriorityC,
@@ -274,7 +274,7 @@ flagshipProductChannelGroup := priority_channel_groups.CombineByFrequencyRatio(c
 
 nicheProductChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
     {
-        PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+        PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
             channels.NewChannelWithFreqRatio(
                 "Niche Product - Paying Customer - High Priority",
                 nicheProductPayingCustomerHighPriorityC,
@@ -287,7 +287,7 @@ nicheProductChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWi
         FreqRatio: 10,
     },
     {
-        PriorityChannel: priority_channels.NewByFrequencyRatio[string]([]channels.ChannelFreqRatio[string]{
+        PriorityChannel: priority_channels.NewByFrequencyRatio[string](ctx, []channels.ChannelFreqRatio[string]{
             channels.NewChannelWithFreqRatio(
                 "Niche Product - Free User - High Priority",
                 nicheProductFreeUserHighPriorityC,
@@ -312,7 +312,7 @@ combinedProductsPriorityChannel := priority_channel_groups.CombineByFrequencyRat
         FreqRatio:       1,
     },
 })
-urgentMessagesPriorityChannel := priority_channels.WrapAsPriorityChannel("Urgent Messages", urgentMessagesC)
+urgentMessagesPriorityChannel := priority_channels.WrapAsPriorityChannel(ctx, "Urgent Messages", urgentMessagesC)
 
 combinedTotalPriorityChannel := priority_channel_groups.CombineByHighestPriorityFirst(ctx, []priority_channel_groups.PriorityChannelWithPriority[string]{
     {
@@ -326,7 +326,7 @@ combinedTotalPriorityChannel := priority_channel_groups.CombineByHighestPriority
 }
 
 for {
-    message, channelName, ok := combinedTotalPriorityChannel.Receive(ctx)
+    message, channelName, ok := combinedTotalPriorityChannel.Receive()
     if !ok {
         break
     }
@@ -422,7 +422,7 @@ func main() {
 
     // receiving messages from the priority channel
     for {
-        message, channelName, ok := ch.Receive(ctx)
+        message, channelName, ok := ch.Receive()
         if !ok {
             break
         }
@@ -462,7 +462,7 @@ func getPriorityChannelByUsagePattern(
                 freeUserLowPriorityC,
                 1),
         }
-        return priority_channels.NewByHighestAlwaysFirst(channelsWithPriority)
+        return priority_channels.NewByHighestAlwaysFirst(ctx, channelsWithPriority)
 
     case FrequencyRatioForAll:
         channelsWithFrequencyRatio := []channels.ChannelFreqRatio[string]{
@@ -483,12 +483,12 @@ func getPriorityChannelByUsagePattern(
                 freeUserLowPriorityC,
                 1),
         }
-        return priority_channels.NewByFrequencyRatio(channelsWithFrequencyRatio)
+        return priority_channels.NewByFrequencyRatio(ctx, channelsWithFrequencyRatio)
 
     case PayingCustomerAlwaysFirst_NoStarvationOfLowMessagesForSameUser:
         priorityChannelsWithPriority := []priority_channel_groups.PriorityChannelWithPriority[string]{
             {
-                PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+                PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
                     channels.NewChannelWithFreqRatio(
                         "Paying Customer - High Priority",
                         payingCustomerHighPriorityC,
@@ -501,7 +501,7 @@ func getPriorityChannelByUsagePattern(
                 Priority: 10,
             },
             {
-                PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+                PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
                     channels.NewChannelWithFreqRatio(
                         "Free User - High Priority",
                         freeUserHighPriorityC,
@@ -519,7 +519,7 @@ func getPriorityChannelByUsagePattern(
     case NoStarvationOfFreeUser_HighPriorityMessagesAlwaysFirstForSameUser:
         priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
             {
-                PriorityChannel: priority_channels.NewByHighestAlwaysFirst([]channels.ChannelWithPriority[string]{
+                PriorityChannel: priority_channels.NewByHighestAlwaysFirst(ctx, []channels.ChannelWithPriority[string]{
                     channels.NewChannelWithPriority(
                         "Paying Customer - High Priority",
                         payingCustomerHighPriorityC,
@@ -532,7 +532,7 @@ func getPriorityChannelByUsagePattern(
                 FreqRatio: 10,
             },
             {
-                PriorityChannel: priority_channels.NewByHighestAlwaysFirst([]channels.ChannelWithPriority[string]{
+                PriorityChannel: priority_channels.NewByHighestAlwaysFirst(ctx, []channels.ChannelWithPriority[string]{
                     channels.NewChannelWithPriority(
                         "Free User - High Priority",
                         freeUserHighPriorityC,
@@ -550,7 +550,7 @@ func getPriorityChannelByUsagePattern(
     case FrequencyRatioBetweenUsers_AndFreqRatioBetweenMessageTypesForSameUser:
         priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
             {
-                PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+                PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
                     channels.NewChannelWithFreqRatio(
                         "Paying Customer - High Priority",
                         payingCustomerHighPriorityC,
@@ -563,7 +563,7 @@ func getPriorityChannelByUsagePattern(
                 FreqRatio: 10,
             },
             {
-                PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+                PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
                     channels.NewChannelWithFreqRatio(
                         "Free User - High Priority",
                         freeUserHighPriorityC,
@@ -581,7 +581,7 @@ func getPriorityChannelByUsagePattern(
     case PriorityForUrgentMessages_FrequencyRatioBetweenUsersAndOtherMessagesTypes:
         priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
             {
-                PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+                PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
                     channels.NewChannelWithFreqRatio(
                         "Paying Customer - High Priority",
                         payingCustomerHighPriorityC,
@@ -594,7 +594,7 @@ func getPriorityChannelByUsagePattern(
                 FreqRatio: 10,
             },
             {
-                PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+                PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
                     channels.NewChannelWithFreqRatio(
                         "Free User - High Priority",
                         freeUserHighPriorityC,
@@ -615,7 +615,7 @@ func getPriorityChannelByUsagePattern(
                 Priority:        1,
             },
             {
-                PriorityChannel: priority_channels.WrapAsPriorityChannel("Urgent Messages", urgentMessagesC),
+                PriorityChannel: priority_channels.WrapAsPriorityChannel(ctx, "Urgent Messages", urgentMessagesC),
                 Priority:        100,
             },
         })

--- a/by_freq.go
+++ b/by_freq.go
@@ -21,7 +21,7 @@ func (pc *priorityChannelsByFreq[T]) Receive() (msg T, channelName string, ok bo
 	return msgReceived.Msg, msgReceived.ChannelName, true
 }
 
-func (pc *priorityChannelsByFreq[T]) ReceiveContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus) {
+func (pc *priorityChannelsByFreq[T]) ReceiveWithContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus) {
 	msgReceived, noMoreMessages := pc.ReceiveSingleMessage(ctx)
 	if noMoreMessages != nil {
 		return getZero[T](), "", noMoreMessages.Reason.ReceiveStatus()

--- a/common.go
+++ b/common.go
@@ -6,7 +6,7 @@ import (
 
 type PriorityChannel[T any] interface {
 	Receive() (msg T, channelName string, ok bool)
-	ReceiveContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus)
+	ReceiveWithContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus)
 }
 
 type ReceiveStatus int
@@ -88,7 +88,7 @@ func (w *wrappedChannel[T]) Receive() (msg T, channelName string, ok bool) {
 	}
 }
 
-func (w *wrappedChannel[T]) ReceiveContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus) {
+func (w *wrappedChannel[T]) ReceiveWithContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus) {
 	select {
 	case <-w.ctx.Done():
 		return getZero[T](), "", ReceiveChannelClosed

--- a/highest_priority_first.go
+++ b/highest_priority_first.go
@@ -9,25 +9,36 @@ import (
 	"github.com/dimag-jfrog/priority-channels/channels"
 )
 
-func NewByHighestAlwaysFirst[T any](channelsWithPriorities []channels.ChannelWithPriority[T]) PriorityChannel[T] {
-	return newPriorityChannelByPriority[T](channelsWithPriorities)
+func NewByHighestAlwaysFirst[T any](ctx context.Context, channelsWithPriorities []channels.ChannelWithPriority[T]) PriorityChannel[T] {
+	return newPriorityChannelByPriority[T](ctx, channelsWithPriorities)
 }
 
-func (pc *priorityChannelsHighestFirst[T]) Receive(ctx context.Context) (msg T, channelName string, ok bool) {
-	msgReceived, noMoreMessages := pc.ReceiveSingleMessage(ctx)
+func (pc *priorityChannelsHighestFirst[T]) Receive() (msg T, channelName string, ok bool) {
+	msgReceived, noMoreMessages := pc.ReceiveSingleMessage(context.Background())
 	if noMoreMessages != nil {
 		return getZero[T](), "", false
 	}
 	return msgReceived.Msg, msgReceived.ChannelName, true
 }
 
+func (pc *priorityChannelsHighestFirst[T]) ReceiveContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus) {
+	msgReceived, noMoreMessages := pc.ReceiveSingleMessage(ctx)
+	if noMoreMessages != nil {
+		return getZero[T](), "", noMoreMessages.Reason.ReceiveStatus()
+	}
+	return msgReceived.Msg, msgReceived.ChannelName, ReceiveSuccess
+}
+
 type priorityChannelsHighestFirst[T any] struct {
+	ctx      context.Context
 	channels []channels.ChannelWithPriority[T]
 }
 
 func newPriorityChannelByPriority[T any](
+	ctx context.Context,
 	channelsWithPriorities []channels.ChannelWithPriority[T]) *priorityChannelsHighestFirst[T] {
 	pq := &priorityChannelsHighestFirst[T]{
+		ctx:      ctx,
 		channels: make([]channels.ChannelWithPriority[T], 0, len(channelsWithPriorities)),
 	}
 
@@ -47,7 +58,7 @@ func ProcessMessagesByPriorityWithHighestAlwaysFirst[T any](
 	ctx context.Context,
 	channelsWithPriorities []channels.ChannelWithPriority[T],
 	msgProcessor func(ctx context.Context, msg T, channelName string)) ExitReason {
-	pq := newPriorityChannelByPriority(channelsWithPriorities)
+	pq := newPriorityChannelByPriority(ctx, channelsWithPriorities)
 	return processPriorityChannelMessages[T](ctx, pq, msgProcessor)
 }
 
@@ -56,7 +67,11 @@ func (pc *priorityChannelsHighestFirst[T]) ReceiveSingleMessage(ctx context.Cont
 		selectCases := pc.prepareSelectCases(ctx, nextPriorityChannelIndex)
 		chosen, recv, recvOk := reflect.Select(selectCases)
 		if chosen == 0 {
-			// ctx.Done Channel
+			// context of the priority channel is done
+			return nil, &noMoreMessagesEvent{Reason: ChannelClosed}
+		}
+		if chosen == 1 {
+			// context of the specific request is done
 			return nil, &noMoreMessagesEvent{Reason: ContextCancelled}
 		}
 		isLastIteration := nextPriorityChannelIndex == len(pc.channels)-1
@@ -71,7 +86,7 @@ func (pc *priorityChannelsHighestFirst[T]) ReceiveSingleMessage(ctx context.Cont
 		}
 		// Message received successfully
 		msg := recv.Interface().(T)
-		res := &msgReceivedEvent[T]{Msg: msg, ChannelName: pc.channels[chosen-1].ChannelName()}
+		res := &msgReceivedEvent[T]{Msg: msg, ChannelName: pc.channels[chosen-2].ChannelName()}
 		return res, nil
 	}
 	return nil, nil
@@ -79,6 +94,10 @@ func (pc *priorityChannelsHighestFirst[T]) ReceiveSingleMessage(ctx context.Cont
 
 func (pc *priorityChannelsHighestFirst[T]) prepareSelectCases(ctx context.Context, currPriorityChannelIndex int) []reflect.SelectCase {
 	var selectCases []reflect.SelectCase
+	selectCases = append(selectCases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(pc.ctx.Done()),
+	})
 	selectCases = append(selectCases, reflect.SelectCase{
 		Dir:  reflect.SelectRecv,
 		Chan: reflect.ValueOf(ctx.Done()),

--- a/highest_priority_first.go
+++ b/highest_priority_first.go
@@ -21,7 +21,7 @@ func (pc *priorityChannelsHighestFirst[T]) Receive() (msg T, channelName string,
 	return msgReceived.Msg, msgReceived.ChannelName, true
 }
 
-func (pc *priorityChannelsHighestFirst[T]) ReceiveContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus) {
+func (pc *priorityChannelsHighestFirst[T]) ReceiveWithContext(ctx context.Context) (msg T, channelName string, status ReceiveStatus) {
 	msgReceived, noMoreMessages := pc.ReceiveSingleMessage(ctx)
 	if noMoreMessages != nil {
 		return getZero[T](), "", noMoreMessages.Reason.ReceiveStatus()

--- a/priority-channel-groups/by_freq.go
+++ b/priority-channel-groups/by_freq.go
@@ -11,7 +11,7 @@ import (
 func CombineByFrequencyRatio[T any](ctx context.Context, priorityChannelsWithFreqRatio []PriorityChannelWithFreqRatio[T]) priority_channels.PriorityChannel[T] {
 	channels := newPriorityChannelsGroupByFreqRatio[T](ctx, priorityChannelsWithFreqRatio)
 	return &priorityChannelOfMsgsWithChannelName[T]{
-		priorityChannel: priority_channels.NewByFrequencyRatio[msgWithChannelName[T]](channels),
+		priorityChannel: priority_channels.NewByFrequencyRatio[msgWithChannelName[T]](ctx, channels),
 	}
 }
 

--- a/priority-channel-groups/by_freq_freq_groups_test.go
+++ b/priority-channel-groups/by_freq_freq_groups_test.go
@@ -21,7 +21,7 @@ func TestProcessMessagesByFreqRatioAmongFreqRatioChannelGroups(t *testing.T) {
 
 	channelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
 		{
-			PriorityChannel: priority_channels.NewByFrequencyRatio[string]([]channels.ChannelFreqRatio[string]{
+			PriorityChannel: priority_channels.NewByFrequencyRatio[string](ctx, []channels.ChannelFreqRatio[string]{
 				channels.NewChannelWithFreqRatio(
 					"Paying Customer - High Priority",
 					payingCustomerHighPriorityC,
@@ -34,7 +34,7 @@ func TestProcessMessagesByFreqRatioAmongFreqRatioChannelGroups(t *testing.T) {
 			FreqRatio: 10,
 		},
 		{
-			PriorityChannel: priority_channels.NewByFrequencyRatio[string]([]channels.ChannelFreqRatio[string]{
+			PriorityChannel: priority_channels.NewByFrequencyRatio[string](ctx, []channels.ChannelFreqRatio[string]{
 				channels.NewChannelWithFreqRatio(
 					"Free User - High Priority",
 					freeUserHighPriorityC,
@@ -79,7 +79,7 @@ func TestProcessMessagesByFreqRatioAmongFreqRatioChannelGroups(t *testing.T) {
 	// receiving messages from the priority channel
 	results := make([]string, 0, 80)
 	for {
-		message, channelName, ok := ch.Receive(ctx)
+		message, channelName, ok := ch.Receive()
 		if !ok {
 			break
 		}

--- a/priority-channel-groups/by_freq_highest_priority_first_groups_test.go
+++ b/priority-channel-groups/by_freq_highest_priority_first_groups_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestProcessMessagesByFreqRatioAmongHighestFirstChannelGroups(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	msgsChannels := make([]chan *Msg, 4)
 	msgsChannels[0] = make(chan *Msg, 15)
 	msgsChannels[1] = make(chan *Msg, 15)
@@ -20,20 +22,20 @@ func TestProcessMessagesByFreqRatioAmongHighestFirstChannelGroups(t *testing.T) 
 
 	channels := []priority_channel_groups.PriorityChannelWithFreqRatio[*Msg]{
 		{
-			PriorityChannel: priority_channels.NewByHighestAlwaysFirst[*Msg]([]channels.ChannelWithPriority[*Msg]{
+			PriorityChannel: priority_channels.NewByHighestAlwaysFirst[*Msg](ctx, []channels.ChannelWithPriority[*Msg]{
 				channels.NewChannelWithPriority("Priority-1", msgsChannels[0], 1),
 				channels.NewChannelWithPriority("Priority-5", msgsChannels[1], 5),
 			}),
 			FreqRatio: 1,
 		},
 		{
-			PriorityChannel: priority_channels.NewByHighestAlwaysFirst[*Msg]([]channels.ChannelWithPriority[*Msg]{
+			PriorityChannel: priority_channels.NewByHighestAlwaysFirst[*Msg](ctx, []channels.ChannelWithPriority[*Msg]{
 				channels.NewChannelWithPriority("Priority-10", msgsChannels[2], 10),
 			}),
 			FreqRatio: 5,
 		},
 		{
-			PriorityChannel: priority_channels.NewByHighestAlwaysFirst[*Msg]([]channels.ChannelWithPriority[*Msg]{
+			PriorityChannel: priority_channels.NewByHighestAlwaysFirst[*Msg](ctx, []channels.ChannelWithPriority[*Msg]{
 				channels.NewChannelWithPriority("Priority-1000", msgsChannels[3], 1000),
 			}),
 			FreqRatio: 10,
@@ -53,7 +55,6 @@ func TestProcessMessagesByFreqRatioAmongHighestFirstChannelGroups(t *testing.T) 
 	msgProcessor := func(_ context.Context, msg *Msg, channelName string) {
 		results = append(results, msg)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
 
 	go priority_channel_groups.ProcessPriorityChannelsByFrequencyRatio(ctx, channels, msgProcessor)
 

--- a/priority-channel-groups/highest_priority_first.go
+++ b/priority-channel-groups/highest_priority_first.go
@@ -11,7 +11,7 @@ import (
 func CombineByHighestPriorityFirst[T any](ctx context.Context, priorityChannelsWithPriority []PriorityChannelWithPriority[T]) priority_channels.PriorityChannel[T] {
 	channels := newPriorityChannelsGroupByHighestPriorityFirst[T](ctx, priorityChannelsWithPriority)
 	return &priorityChannelOfMsgsWithChannelName[T]{
-		priorityChannel: priority_channels.NewByHighestAlwaysFirst[msgWithChannelName[T]](channels),
+		priorityChannel: priority_channels.NewByHighestAlwaysFirst[msgWithChannelName[T]](ctx, channels),
 	}
 }
 

--- a/priority-channel-groups/highest_priority_first_freq_groups_test.go
+++ b/priority-channel-groups/highest_priority_first_freq_groups_test.go
@@ -17,6 +17,8 @@ type Msg struct {
 }
 
 func TestProcessMessagesByPriorityAmongFreqRatioChannelGroups(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	msgsChannels := make([]chan *Msg, 4)
 	msgsChannels[0] = make(chan *Msg, 15)
 	msgsChannels[1] = make(chan *Msg, 15)
@@ -25,20 +27,20 @@ func TestProcessMessagesByPriorityAmongFreqRatioChannelGroups(t *testing.T) {
 
 	channels := []priority_channel_groups.PriorityChannelWithPriority[*Msg]{
 		{
-			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg]([]channels.ChannelFreqRatio[*Msg]{
+			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg](ctx, []channels.ChannelFreqRatio[*Msg]{
 				channels.NewChannelWithFreqRatio("Priority-1", msgsChannels[0], 1),
 				channels.NewChannelWithFreqRatio("Priority-5", msgsChannels[1], 5),
 			}),
 			Priority: 1,
 		},
 		{
-			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg]([]channels.ChannelFreqRatio[*Msg]{
+			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg](ctx, []channels.ChannelFreqRatio[*Msg]{
 				channels.NewChannelWithFreqRatio("Priority-10", msgsChannels[2], 1),
 			}),
 			Priority: 10,
 		},
 		{
-			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg]([]channels.ChannelFreqRatio[*Msg]{
+			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg](ctx, []channels.ChannelFreqRatio[*Msg]{
 				channels.NewChannelWithFreqRatio("Priority-1000", msgsChannels[3], 1),
 			}),
 			Priority: 1000,
@@ -58,7 +60,6 @@ func TestProcessMessagesByPriorityAmongFreqRatioChannelGroups(t *testing.T) {
 	msgProcessor := func(_ context.Context, msg *Msg, channelName string) {
 		results = append(results, msg)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
 
 	go priority_channel_groups.ProcessPriorityChannelsByPriorityWithHighestAlwaysFirst(ctx, channels, msgProcessor)
 
@@ -126,6 +127,8 @@ func TestProcessMessagesByPriorityAmongFreqRatioChannelGroups(t *testing.T) {
 }
 
 func TestProcessMessagesByPriorityAmongFreqRatioChannelGroups_MessagesInOneOfTheChannelsArriveAfterSomeTime(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	msgsChannels := make([]chan *Msg, 3)
 	msgsChannels[0] = make(chan *Msg, 7)
 	msgsChannels[1] = make(chan *Msg, 7)
@@ -133,14 +136,14 @@ func TestProcessMessagesByPriorityAmongFreqRatioChannelGroups_MessagesInOneOfThe
 
 	channels := []priority_channel_groups.PriorityChannelWithPriority[*Msg]{
 		{
-			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg]([]channels.ChannelFreqRatio[*Msg]{
+			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg](ctx, []channels.ChannelFreqRatio[*Msg]{
 				channels.NewChannelWithFreqRatio("Priority-1", msgsChannels[0], 1),
 				channels.NewChannelWithFreqRatio("Priority-2", msgsChannels[1], 2),
 			}),
 			Priority: 1,
 		},
 		{
-			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg]([]channels.ChannelFreqRatio[*Msg]{
+			PriorityChannel: priority_channels.NewByFrequencyRatio[*Msg](ctx, []channels.ChannelFreqRatio[*Msg]{
 				channels.NewChannelWithFreqRatio("Priority-3", msgsChannels[2], 1),
 			}),
 			Priority: 2,
@@ -165,7 +168,6 @@ func TestProcessMessagesByPriorityAmongFreqRatioChannelGroups_MessagesInOneOfThe
 		}
 		results = append(results, msg)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
 
 	go priority_channel_groups.ProcessPriorityChannelsByPriorityWithHighestAlwaysFirst(ctx, channels, msgProcessor)
 

--- a/priority-channel-groups/msg_with_channel_name.go
+++ b/priority-channel-groups/msg_with_channel_name.go
@@ -23,8 +23,8 @@ func (pc *priorityChannelOfMsgsWithChannelName[T]) Receive() (msg T, channelName
 	return msgWithChannelName.Msg, msgWithChannelName.ChannelName, true
 }
 
-func (pc *priorityChannelOfMsgsWithChannelName[T]) ReceiveContext(ctx context.Context) (msg T, channelName string, status priority_channels.ReceiveStatus) {
-	msgWithChannelName, _, status := pc.priorityChannel.ReceiveContext(ctx)
+func (pc *priorityChannelOfMsgsWithChannelName[T]) ReceiveWithContext(ctx context.Context) (msg T, channelName string, status priority_channels.ReceiveStatus) {
+	msgWithChannelName, _, status := pc.priorityChannel.ReceiveWithContext(ctx)
 	if status != priority_channels.ReceiveSuccess {
 		return getZero[T](), "", status
 	}

--- a/priority-channel-groups/msg_with_channel_name.go
+++ b/priority-channel-groups/msg_with_channel_name.go
@@ -15,19 +15,27 @@ type priorityChannelOfMsgsWithChannelName[T any] struct {
 	priorityChannel priority_channels.PriorityChannel[msgWithChannelName[T]]
 }
 
-func (pc *priorityChannelOfMsgsWithChannelName[T]) Receive(ctx context.Context) (msg T, channelName string, ok bool) {
-	msgWithChannelName, _, ok := pc.priorityChannel.Receive(ctx)
+func (pc *priorityChannelOfMsgsWithChannelName[T]) Receive() (msg T, channelName string, ok bool) {
+	msgWithChannelName, _, ok := pc.priorityChannel.Receive()
 	if !ok {
 		return getZero[T](), "", false
 	}
 	return msgWithChannelName.Msg, msgWithChannelName.ChannelName, true
 }
 
+func (pc *priorityChannelOfMsgsWithChannelName[T]) ReceiveContext(ctx context.Context) (msg T, channelName string, status priority_channels.ReceiveStatus) {
+	msgWithChannelName, _, status := pc.priorityChannel.ReceiveContext(ctx)
+	if status != priority_channels.ReceiveSuccess {
+		return getZero[T](), "", status
+	}
+	return msgWithChannelName.Msg, msgWithChannelName.ChannelName, status
+}
+
 func processPriorityChannelToMsgsWithChannelName[T any](ctx context.Context, priorityChannel priority_channels.PriorityChannel[T]) <-chan msgWithChannelName[T] {
 	msgWithNameC := make(chan msgWithChannelName[T])
 	go func() {
 		for {
-			message, channelName, ok := priorityChannel.Receive(ctx)
+			message, channelName, ok := priorityChannel.Receive()
 			if !ok {
 				break
 			}

--- a/priority_channels_test.go
+++ b/priority_channels_test.go
@@ -110,7 +110,7 @@ func testExample(t *testing.T, usagePattern UsagePattern) {
 
 	// receiving messages from the priority channel
 	for {
-		message, channelName, ok := ch.Receive(ctx)
+		message, channelName, ok := ch.Receive()
 		if !ok {
 			break
 		}
@@ -150,7 +150,7 @@ func getPriorityChannelByUsagePattern(
 				freeUserLowPriorityC,
 				1),
 		}
-		return priority_channels.NewByHighestAlwaysFirst(channelsWithPriority)
+		return priority_channels.NewByHighestAlwaysFirst(ctx, channelsWithPriority)
 
 	case FrequencyRatioForAll:
 		channelsWithFrequencyRatio := []channels.ChannelFreqRatio[string]{
@@ -171,12 +171,12 @@ func getPriorityChannelByUsagePattern(
 				freeUserLowPriorityC,
 				1),
 		}
-		return priority_channels.NewByFrequencyRatio(channelsWithFrequencyRatio)
+		return priority_channels.NewByFrequencyRatio(ctx, channelsWithFrequencyRatio)
 
 	case PayingCustomerAlwaysFirst_NoStarvationOfLowMessagesForSameUser:
 		priorityChannelsWithPriority := []priority_channel_groups.PriorityChannelWithPriority[string]{
 			{
-				PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+				PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
 					channels.NewChannelWithFreqRatio(
 						"Paying Customer - High Priority",
 						payingCustomerHighPriorityC,
@@ -189,7 +189,7 @@ func getPriorityChannelByUsagePattern(
 				Priority: 10,
 			},
 			{
-				PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+				PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
 					channels.NewChannelWithFreqRatio(
 						"Free User - High Priority",
 						freeUserHighPriorityC,
@@ -207,7 +207,7 @@ func getPriorityChannelByUsagePattern(
 	case NoStarvationOfFreeUser_HighPriorityMessagesAlwaysFirstForSameUser:
 		priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
 			{
-				PriorityChannel: priority_channels.NewByHighestAlwaysFirst([]channels.ChannelWithPriority[string]{
+				PriorityChannel: priority_channels.NewByHighestAlwaysFirst(ctx, []channels.ChannelWithPriority[string]{
 					channels.NewChannelWithPriority(
 						"Paying Customer - High Priority",
 						payingCustomerHighPriorityC,
@@ -220,7 +220,7 @@ func getPriorityChannelByUsagePattern(
 				FreqRatio: 10,
 			},
 			{
-				PriorityChannel: priority_channels.NewByHighestAlwaysFirst([]channels.ChannelWithPriority[string]{
+				PriorityChannel: priority_channels.NewByHighestAlwaysFirst(ctx, []channels.ChannelWithPriority[string]{
 					channels.NewChannelWithPriority(
 						"Free User - High Priority",
 						freeUserHighPriorityC,
@@ -238,7 +238,7 @@ func getPriorityChannelByUsagePattern(
 	case FrequencyRatioBetweenUsers_AndFreqRatioBetweenMessageTypesForSameUser:
 		priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
 			{
-				PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+				PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
 					channels.NewChannelWithFreqRatio(
 						"Paying Customer - High Priority",
 						payingCustomerHighPriorityC,
@@ -251,7 +251,7 @@ func getPriorityChannelByUsagePattern(
 				FreqRatio: 10,
 			},
 			{
-				PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+				PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
 					channels.NewChannelWithFreqRatio(
 						"Free User - High Priority",
 						freeUserHighPriorityC,
@@ -269,7 +269,7 @@ func getPriorityChannelByUsagePattern(
 	case PriorityForUrgentMessages_FrequencyRatioBetweenUsersAndOtherMessagesTypes:
 		priorityChannelsWithFreqRatio := []priority_channel_groups.PriorityChannelWithFreqRatio[string]{
 			{
-				PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+				PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
 					channels.NewChannelWithFreqRatio(
 						"Paying Customer - High Priority",
 						payingCustomerHighPriorityC,
@@ -282,7 +282,7 @@ func getPriorityChannelByUsagePattern(
 				FreqRatio: 10,
 			},
 			{
-				PriorityChannel: priority_channels.NewByFrequencyRatio([]channels.ChannelFreqRatio[string]{
+				PriorityChannel: priority_channels.NewByFrequencyRatio(ctx, []channels.ChannelFreqRatio[string]{
 					channels.NewChannelWithFreqRatio(
 						"Free User - High Priority",
 						freeUserHighPriorityC,
@@ -303,7 +303,7 @@ func getPriorityChannelByUsagePattern(
 				Priority:        1,
 			},
 			{
-				PriorityChannel: priority_channels.WrapAsPriorityChannel("Urgent Messages", urgentMessagesC),
+				PriorityChannel: priority_channels.WrapAsPriorityChannel(ctx, "Urgent Messages", urgentMessagesC),
 				Priority:        100,
 			},
 		})


### PR DESCRIPTION
Adding context to priority channel creation, separating it from context for single request and using 2 methods: Request and RequestWithContext